### PR TITLE
Add read_at column to notifications structure

### DIFF
--- a/database/fix_notifications_structure.sql
+++ b/database/fix_notifications_structure.sql
@@ -5,7 +5,8 @@
 DESCRIBE notifications;
 
 -- เพิ่มคอลัมน์ที่อาจจะขาดหายไป
-ALTER TABLE notifications 
+ALTER TABLE notifications
+ADD COLUMN IF NOT EXISTS read_at DATETIME NULL AFTER metadata,
 ADD COLUMN IF NOT EXISTS is_public TINYINT(1) DEFAULT 0 AFTER priority,
 ADD COLUMN IF NOT EXISTS is_active TINYINT(1) DEFAULT 1 AFTER is_public,
 ADD COLUMN IF NOT EXISTS expires_at DATETIME NULL AFTER is_active,


### PR DESCRIPTION
## Summary
- allow tracking notification reading time by adding optional `read_at` column

## Testing
- `mysql -u user -ppassword dbname < database/fix_notifications_structure.sql` *(fails: Can't connect to local MySQL server)*
- `mysql -u user -ppassword -e "DESCRIBE notifications;" dbname` *(fails: Can't connect to local MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68b128ab598c832e8c4e1d9d7cd27ae8