### PR TITLE
Expose extra notification fields for monitor API

### DIFF
--- a/api/get_monitor_notifications.php
+++ b/api/get_monitor_notifications.php
@@ -23,6 +23,10 @@ try {
         n.created_at,
         n.read_at,
         n.metadata,
+        n.expires_at,
+        n.auto_dismiss_after,
+        n.color,
+        n.icon,
         sp.point_name as service_point_name
     FROM notifications n
     LEFT JOIN service_points sp ON n.service_point_id = sp.service_point_id


### PR DESCRIPTION
## Summary
- include `expires_at`, `auto_dismiss_after`, `color`, and `icon` in monitor notification query so frontend gets display info

## Testing
- `php -l api/get_monitor_notifications.php`
- `composer test` *(fails: phpunit: not found)*
- `php get_monitor_notifications.php` *(fails: .env file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b129221974832ebe82cd094afc4f7d