### PR TITLE
Fix monitor notifications query missing column

### DIFF
--- a/api/get_monitor_notifications.php
+++ b/api/get_monitor_notifications.php
@@ -21,7 +21,6 @@ try {
         n.message,
         n.priority,
         n.created_at,
-        n.read_at,
         n.metadata,
         n.expires_at,
         n.auto_dismiss_after,


### PR DESCRIPTION
## Summary
- remove `read_at` from monitor notifications query to match `notifications` table

## Testing
- `php -l api/get_monitor_notifications.php`
- `php -r '$_GET["service_point_id"]=1; include "get_monitor_notifications.php";'` *(fails: .env file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b12b2c0508832ea997c4797ce140c4