### PR TITLE
Handle custom message defaults in play queue audio

### DIFF
--- a/api/play_queue_audio.php
+++ b/api/play_queue_audio.php
@@ -99,6 +99,8 @@ try {
     } else {
         $message = $customMessage;
         $queueData = null;
+        $templateText = $customMessage ?? '';
+        $servicePointName = '';
     }
     
     $audioRepeatCount = intval(getSetting('audio_repeat_count', '1'));
@@ -115,7 +117,10 @@ try {
         return $row['file_path'] ?? null;
     };
 
-    $segments = preg_split('/({[^}]+})/', $templateText, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+    $templateText = is_string($templateText) ? $templateText : '';
+    $segments = $templateText === ''
+        ? []
+        : preg_split('/({[^}]+})/', $templateText, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
     foreach ($segments as $segment) {
         if (preg_match('/^{([^}]+)}$/', $segment, $m)) {
             switch ($m[1]) {


### PR DESCRIPTION
## Summary
- Set template and service point defaults when using custom message
- Guard preg_split call by ensuring template text is a string

## Testing
- `php -l api/play_queue_audio.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1320419f8832eaa8c67e47528e029