### PR TITLE
Initialize servicePointName in play queue audio custom flow

### DIFF
--- a/api/play_queue_audio.php
+++ b/api/play_queue_audio.php
@@ -99,6 +99,7 @@ try {
     } else {
         $message = $customMessage;
         $queueData = null;
+        $servicePointName = '';
     }
     
     $audioRepeatCount = intval(getSetting('audio_repeat_count', '1'));


### PR DESCRIPTION
## Summary
- initialize `$servicePointName` when playing custom queue audio to avoid undefined variable notices

## Testing
- `php -l api/play_queue_audio.php`


------
https://chatgpt.com/codex/tasks/task_e_68b13208c46c832e8a7b72b87bccad6c