### PR TITLE
feat: support per-service point labels

### DIFF
--- a/admin/nav.php
+++ b/admin/nav.php
@@ -4,7 +4,7 @@ $navItems = [
     ['dashboard.php', 'fas fa-tachometer-alt', 'แดชบอร์ด'],
     ['users.php', 'fas fa-users', 'จัดการผู้ใช้'],
     ['roles.php', 'fas fa-user-tag', 'บทบาทและสิทธิ์'],
-    ['service_points.php', 'fas fa-map-marker-alt', 'จุดบริการ'],
+    ['service_points.php', 'fas fa-map-marker-alt', getServicePointLabel()],
     ['queue_types.php', 'fas fa-list', 'ประเภทคิว'],
     ['service_flows.php', 'fas fa-route', 'Service Flows'],
     ['queue_management.php', 'fas fa-tasks', 'จัดการคิว'],

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -74,7 +74,8 @@ $currentSettings = [
     'display_refresh_interval' => getSetting('display_refresh_interval', '3'),
     'enable_priority_queue' => getSetting('enable_priority_queue', 'true'),
     'auto_forward_enabled' => getSetting('auto_forward_enabled', 'false'),
-    
+    'service_point_label' => getSetting('service_point_label', 'จุดบริการ'),
+
     // Working Hours
     'working_hours_start' => getSetting('working_hours_start', '08:00'),
     'working_hours_end' => getSetting('working_hours_end', '16:00'),
@@ -339,12 +340,20 @@ $currentSettings = [
                                 </div>
                                 
                                 <div class="form-check form-switch mb-3">
-                                    <input class="form-check-input" type="checkbox" name="settings[auto_forward_enabled]" 
+                                    <input class="form-check-input" type="checkbox" name="settings[auto_forward_enabled]"
                                            value="true" <?php echo $currentSettings['auto_forward_enabled'] == 'true' ? 'checked' : ''; ?>>
                                     <label class="form-check-label">ส่งต่อคิวอัตโนมัติ</label>
                                 </div>
+
+                                <div class="mb-3">
+                                    <label class="form-label">คำเรียกจุดบริการ</label>
+                                    <input type="text" class="form-control" name="settings[service_point_label]"
+                                           value="<?php echo htmlspecialchars($currentSettings['service_point_label']); ?>"
+                                           placeholder="เช่น ช่อง, จุดรับบริการ, บริเวณ, ห้อง">
+                                    <div class="form-text">กำหนดชื่อที่ใช้เรียกจุดบริการในระบบ</div>
+                                </div>
                             </div>
-                            
+
                             <!-- Audio Settings -->
                             <div class="setting-group">
                                 <h6><i class="fas fa-volume-up me-2"></i>การตั้งค่าเสียง</h6>

--- a/api/get_monitor_data.php
+++ b/api/get_monitor_data.php
@@ -13,7 +13,7 @@ try {
         
         // Current queue
         $stmt = $db->prepare("
-            SELECT q.*, qt.type_name, sp.point_name as service_point_name
+            SELECT q.*, qt.type_name, TRIM(CONCAT(COALESCE(sp.point_label,''),' ', sp.point_name)) as service_point_name
             FROM queues q
             LEFT JOIN queue_types qt ON q.queue_type_id = qt.queue_type_id
             LEFT JOIN service_points sp ON q.current_service_point_id = sp.service_point_id
@@ -42,7 +42,7 @@ try {
         
         // Current queues being called
         $stmt = $db->prepare("
-            SELECT q.*, qt.type_name, sp.point_name as service_point_name
+            SELECT q.*, qt.type_name, TRIM(CONCAT(COALESCE(sp.point_label,''),' ', sp.point_name)) as service_point_name
             FROM queues q
             LEFT JOIN queue_types qt ON q.queue_type_id = qt.queue_type_id
             LEFT JOIN service_points sp ON q.current_service_point_id = sp.service_point_id
@@ -55,7 +55,7 @@ try {
         
         // All waiting queues
         $stmt = $db->prepare("
-            SELECT q.*, qt.type_name, sp.point_name as service_point_name
+            SELECT q.*, qt.type_name, TRIM(CONCAT(COALESCE(sp.point_label,''),' ', sp.point_name)) as service_point_name
             FROM queues q
             LEFT JOIN queue_types qt ON q.queue_type_id = qt.queue_type_id
             LEFT JOIN service_points sp ON q.current_service_point_id = sp.service_point_id

--- a/api/get_service_points_status.php
+++ b/api/get_service_points_status.php
@@ -7,7 +7,7 @@ header('Content-Type: application/json');
 try {
     $db = getDB();
     $stmt = $db->prepare("
-        SELECT sp.point_name,
+        SELECT TRIM(CONCAT(COALESCE(sp.point_label,''),' ', sp.point_name)) AS point_name,
                CASE WHEN q.queue_id IS NOT NULL THEN 1 ELSE 0 END as has_active_queue
         FROM service_points sp
         LEFT JOIN queues q ON sp.service_point_id = q.current_service_point_id 

--- a/api/play_queue_audio.php
+++ b/api/play_queue_audio.php
@@ -38,7 +38,7 @@ try {
                 q.queue_number,
                 p.name AS patient_name,
                 q.current_service_point_id,
-                sp.point_name AS service_point_name,
+                TRIM(CONCAT(COALESCE(sp.point_label,''),' ', sp.point_name)) AS service_point_name,
                 sp.voice_template_id
             FROM queues q
             LEFT JOIN service_points sp ON q.current_service_point_id = sp.service_point_id

--- a/config/config.php
+++ b/config/config.php
@@ -301,6 +301,15 @@ function getAppName() {
     return getSetting('app_name', 'โรงพยาบาลยุวประสาทไวทโยปถัมภ์');
 }
 
+/**
+ * Get the label used for service points throughout the system
+ *
+ * @return string
+ */
+function getServicePointLabel() {
+    return getSetting('service_point_label', 'จุดบริการ');
+}
+
 function formatFileSize($bytes) {
     $units = ['B', 'KB', 'MB', 'GB'];
     $bytes = max($bytes, 0);

--- a/database/yuwaprasart_queue.sql
+++ b/database/yuwaprasart_queue.sql
@@ -1374,6 +1374,7 @@ INSERT INTO `service_flows` VALUES (4, 1, 2, 5, 3, 0, 1);
 DROP TABLE IF EXISTS `service_points`;
 CREATE TABLE `service_points`  (
   `service_point_id` int NOT NULL AUTO_INCREMENT,
+  `point_label` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL,
   `point_name` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
   `point_description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL,
   `position_key` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
@@ -1395,12 +1396,12 @@ CREATE TABLE `service_points`  (
 -- ----------------------------
 -- Records of service_points
 -- ----------------------------
-INSERT INTO `service_points` VALUES (1, 'จุดคัดกรอง', 'จุดคัดกรองผู้ป่วยเบื้องต้น', 'SCREENING_01', 1, 1, NULL, NULL, '2025-06-19 16:30:13');
-INSERT INTO `service_points` VALUES (2, 'ห้องตรวจ 1', 'ห้องตรวจแพทย์ห้องที่ 1', 'DOCTOR_01', 1, 2, NULL, NULL, '2025-06-19 16:30:13');
-INSERT INTO `service_points` VALUES (3, 'ห้องตรวจ 2', 'ห้องตรวจแพทย์ห้องที่ 2', 'DOCTOR_02', 1, 3, NULL, NULL, '2025-06-19 16:30:13');
-INSERT INTO `service_points` VALUES (4, 'ห้องเภสัช', 'จุดรับยา', 'PHARMACY_01', 1, 4, NULL, NULL, '2025-06-19 16:30:13');
-INSERT INTO `service_points` VALUES (5, 'การเงิน', 'จุดชำระเงิน', 'CASHIER_01', 1, 5, NULL, NULL, '2025-06-19 16:30:13');
-INSERT INTO `service_points` VALUES (6, 'เวชระเบียน', 'จุดบริการเวชระเบียน', 'RECORDS_01', 1, 6, NULL, NULL, '2025-06-19 16:30:13');
+INSERT INTO `service_points` VALUES (1, NULL, 'จุดคัดกรอง', 'จุดคัดกรองผู้ป่วยเบื้องต้น', 'SCREENING_01', 1, 1, NULL, NULL, '2025-06-19 16:30:13');
+INSERT INTO `service_points` VALUES (2, NULL, 'ห้องตรวจ 1', 'ห้องตรวจแพทย์ห้องที่ 1', 'DOCTOR_01', 1, 2, NULL, NULL, '2025-06-19 16:30:13');
+INSERT INTO `service_points` VALUES (3, NULL, 'ห้องตรวจ 2', 'ห้องตรวจแพทย์ห้องที่ 2', 'DOCTOR_02', 1, 3, NULL, NULL, '2025-06-19 16:30:13');
+INSERT INTO `service_points` VALUES (4, NULL, 'ห้องเภสัช', 'จุดรับยา', 'PHARMACY_01', 1, 4, NULL, NULL, '2025-06-19 16:30:13');
+INSERT INTO `service_points` VALUES (5, NULL, 'การเงิน', 'จุดชำระเงิน', 'CASHIER_01', 1, 5, NULL, NULL, '2025-06-19 16:30:13');
+INSERT INTO `service_points` VALUES (6, NULL, 'เวชระเบียน', 'จุดบริการเวชระเบียน', 'RECORDS_01', 1, 6, NULL, NULL, '2025-06-19 16:30:13');
 
 -- ----------------------------
 -- Table structure for settings


### PR DESCRIPTION
## Summary
- allow each service point to define its own label prefix
- use combined label+name across admin, status APIs and audio calls
- document new `point_label` column in SQL schema
- preload audio files on monitor display to avoid missing service point clips

## Testing
- ✅ `php -l admin/service_points.php api/get_service_points_status.php api/get_monitor_data.php api/play_queue_audio.php check_status.php monitor/display.php`
- ⚠️ `composer test` (phpunit: not found)
- ⚠️ `npm test` (jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b554d7802c832ebdbc85518aefedde