### PR TITLE
Improve queue audio reliability and staff notifications

### DIFF
--- a/api/get_queues.php
+++ b/api/get_queues.php
@@ -43,13 +43,12 @@ try {
     
     // Get waiting queues
     $stmt = $db->prepare("
-        SELECT q.*, qt.type_name 
+        SELECT q.*, qt.type_name
         FROM queues q
         LEFT JOIN queue_types qt ON q.queue_type_id = qt.queue_type_id
-        WHERE q.current_service_point_id = ? 
+        WHERE q.current_service_point_id = ?
         AND q.current_status = 'waiting'
         ORDER BY q.priority_level DESC, q.creation_time ASC
-        LIMIT 20
     ");
     $stmt->execute([$servicePointId]);
     $waitingQueues = $stmt->fetchAll();

--- a/api/report_audio_issue.php
+++ b/api/report_audio_issue.php
@@ -1,0 +1,42 @@
+<?php
+require_once '../config/config.php';
+require_once 'notification_center.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Method Not Allowed']);
+    exit;
+}
+
+$queueId = isset($_POST['queue_id']) ? (int)$_POST['queue_id'] : null;
+$servicePointId = isset($_POST['service_point_id']) ? (int)$_POST['service_point_id'] : null;
+$missingFiles = isset($_POST['missing_files']) ? json_decode($_POST['missing_files'], true) : [];
+
+if (empty($missingFiles)) {
+    echo json_encode(['success' => false, 'message' => 'No missing files reported']);
+    exit;
+}
+
+try {
+    $fileList = is_array($missingFiles) ? implode(', ', $missingFiles) : strval($missingFiles);
+    $title = 'ปัญหาเสียงเรียกคิว';
+    $message = 'ไม่สามารถโหลดไฟล์เสียงต่อไปนี้ได้: ' . $fileList;
+    if ($queueId) {
+        $message .= " (Queue ID: {$queueId})";
+    }
+    if ($servicePointId) {
+        $message .= " (Service Point: {$servicePointId})";
+    }
+
+    $result = createNotification('system_alert', $title, $message, [
+        'priority' => 'urgent'
+    ]);
+
+    echo json_encode(['success' => $result['success'], 'message' => $result['message']]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Error reporting audio issue', 'error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- Ensure full waiting queue retrieval by removing fetch limit in `get_queues.php`
- Detect and report missing queue audio files and create system alerts for staff
- Poll staff notifications and show alerts in dashboard
- Reload audio when a queue is recalled by tracking call time, stopping current clips, and forcing a fresh audio fetch
- Add cache-busting and CSRF tokens to staff dashboard requests for more reliable queue actions

## Testing
- `php -l monitor/display.php`
- `php -l staff/dashboard.php`
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: dropzone@^6.0.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f5e555cc832ebadb8cda79c50e62