### PR TITLE
Fix TTS command escaping for audio API

### DIFF
--- a/includes/tts_helpers.php
+++ b/includes/tts_helpers.php
@@ -62,13 +62,64 @@ if (!function_exists('synthesizeTtsAudio')) {
         if ($jsonEncoded === false) {
             throw new Exception('ไม่สามารถเตรียมข้อความสำหรับส่งไปยัง API ได้');
         }
-        $jsonEncoded = substr($jsonEncoded, 1, -1); // remove surrounding quotes
+        $jsonWithoutQuotes = substr($jsonEncoded, 1, -1); // remove surrounding quotes
 
-        $command = str_replace(
-            [$placeholder, $altPlaceholder],
-            $jsonEncoded,
-            $commandTemplate
-        );
+        $command = $commandTemplate;
+
+        $envExport = 'TTS_TEXT_JSON_SAFE=' . escapeshellarg($jsonWithoutQuotes)
+            . ' TTS_TEXT_RAW=' . escapeshellarg($text);
+
+        $placeholders = [$placeholder, $altPlaceholder];
+
+        foreach ($placeholders as $ph) {
+            if ($ph === '') {
+                continue;
+            }
+
+            // Handle placeholders that live inside single quoted strings
+            $command = preg_replace_callback(
+                "/'([^']*?)" . preg_quote($ph, '/') . "([^']*?)'/",
+                function (array $matches): string {
+                    $segments = [];
+
+                    if ($matches[1] !== '') {
+                        $segments[] = "'" . $matches[1] . "'";
+                    }
+
+                    $segments[] = '"$TTS_TEXT_JSON_SAFE"';
+
+                    if ($matches[2] !== '') {
+                        $segments[] = "'" . $matches[2] . "'";
+                    }
+
+                    $filtered = [];
+                    foreach ($segments as $segment) {
+                        if ($segment !== "''") {
+                            $filtered[] = $segment;
+                        }
+                    }
+
+                    return implode('', $filtered);
+                },
+                $command
+            );
+
+            // Handle placeholders wrapped in double quotes
+            $command = preg_replace(
+                '/"' . preg_quote($ph, '/') . '"/',
+                '"$TTS_TEXT_JSON_SAFE"',
+                $command
+            );
+
+            // Replace any remaining occurrences with a shell-safe default
+            $command = str_replace($ph, '"$TTS_TEXT_JSON_SAFE"', $command);
+        }
+
+        if (strpos($command, $placeholder) !== false || strpos($command, $altPlaceholder) !== false) {
+            throw new Exception('ไม่สามารถเตรียมคำสั่งเรียก API ได้: พบตัวแปร {{_TEXT_TO_SPECH_}} ที่ไม่ได้ถูกแทนค่า');
+        }
+
+        $command = $envExport . ' ' . $command;
 
         $descriptorspec = [
             0 => ['pipe', 'r'],

--- a/python_api/tts_service.py
+++ b/python_api/tts_service.py
@@ -1,0 +1,82 @@
+"""Simple gTTS-based HTTP API compatible with the queue audio system."""
+from __future__ import annotations
+
+import io
+import os
+from typing import Any, Dict
+
+from flask import Flask, Response, jsonify, request, send_file
+from gtts import gTTS
+
+
+DEFAULT_LANG = os.getenv("TTS_DEFAULT_LANG", "th")
+DEFAULT_TLD = os.getenv("TTS_DEFAULT_TLD", "com")
+DEFAULT_FILENAME = os.getenv("TTS_DEFAULT_FILENAME", "speech.mp3")
+MAX_TEXT_LENGTH = int(os.getenv("TTS_MAX_TEXT_LENGTH", "800"))
+
+app = Flask(__name__)
+
+
+def _error(message: str, status: int = 400) -> Response:
+    payload: Dict[str, Any] = {"success": False, "message": message}
+    response = jsonify(payload)
+    response.status_code = status
+    return response
+
+
+@app.post("/tts")
+def synthesize() -> Response:
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return _error("กรุณาส่งข้อมูลในรูปแบบ JSON")
+
+    text = str(data.get("text", "")).strip()
+    if not text:
+        return _error("กรุณาระบุข้อความสำหรับแปลงเป็นเสียง")
+
+    if len(text) > MAX_TEXT_LENGTH:
+        return _error(f"ข้อความยาวเกินกำหนด ({MAX_TEXT_LENGTH} อักขระ)")
+
+    lang = str(data.get("lang", DEFAULT_LANG)).strip() or DEFAULT_LANG
+    slow_raw = data.get("slow", False)
+    if isinstance(slow_raw, str):
+        slow = slow_raw.lower() in {"1", "true", "yes"}
+    else:
+        slow = bool(slow_raw)
+    tld = str(data.get("tld", DEFAULT_TLD)).strip() or DEFAULT_TLD
+    filename = str(data.get("filename", DEFAULT_FILENAME)).strip() or DEFAULT_FILENAME
+
+    # gTTS expects language code without region, e.g. "th" from "th-TH"
+    lang_short = lang.split("-")[0]
+
+    try:
+        tts = gTTS(text=text, lang=lang_short, slow=slow, tld=tld)
+        audio_io = io.BytesIO()
+        tts.write_to_fp(audio_io)
+        audio_io.seek(0)
+    except ValueError as exc:
+        return _error(f"ไม่รองรับภาษาหรือการตั้งค่าที่ระบุ: {exc}")
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        return _error(f"ไม่สามารถสร้างเสียงได้: {exc}", status=500)
+
+    response = send_file(
+        audio_io,
+        mimetype="audio/mpeg",
+        as_attachment=False,
+        download_name=filename if filename.lower().endswith(".mp3") else f"{filename}.mp3",
+    )
+    response.headers["X-TTS-Engine"] = "gTTS"
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+@app.get("/health")
+def health() -> Response:
+    return jsonify({"success": True, "engine": "gTTS"})
+
+
+if __name__ == "__main__":
+    host = os.getenv("TTS_API_HOST", "0.0.0.0")
+    port = int(os.getenv("TTS_API_PORT", "5000"))
+    debug = os.getenv("TTS_API_DEBUG", "false").lower() in {"1", "true", "yes"}
+    app.run(host=host, port=port, debug=debug)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 google-cloud-texttospeech>=2.0.0,<3.0.0
 gTTS>=2.5.0,<3.0.0
+Flask>=2.2.0,<3.0.0


### PR DESCRIPTION
## Summary
- export the rendered queue text into environment assignments before running custom curl commands
- update placeholder replacement to be shell-aware and allow single-quoted segments to expand via $TTS_TEXT_JSON_SAFE
- ensure all remaining substitutions fall back to a safe double-quoted variable and run curl with the populated environment

## Testing
- php -l includes/tts_helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68dca202b3c0832e9dd2507d53fd957b